### PR TITLE
Modify kubelet spawning to be independent of docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ kmachine_*
 *.log
 *.iml
 .idea/
-./bin
+bin/
 cover

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,6 @@ test: .ignore
 				make $@
 
 		test ! -d bin || rm -Rf bin
-		test -z "$(findstring build,$(patsubst cross,build,$@))" || docker cp $(DOCKER_CONTAINER_NAME):/go/src/github.com/docker/machine/bin bin
+		test -z "$(findstring build,$(patsubst cross,build,$@))" || docker cp $(DOCKER_CONTAINER_NAME):/go/src/github.com/docker/machine/bin .
 
 endif

--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -242,8 +242,8 @@ users:
 	return &k8sOptions{
 		k8sOptions:     k8sCfg.String(),
 		k8sOptionsPath: provisioner.KubernetesManifestFile,
-    k8sKubeletCfg:  k8sKubeletCfg.String(),
     k8sKubeletPath: provisioner.KubernetesKubeletPath,
+    k8sKubeletCfg:  k8sKubeletCfg.String(),
     k8sPolicyCfg:   k8sPolicyCfg,
 	}, nil
 }

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -26,6 +26,7 @@ func NewUbuntuProvisioner(d drivers.Driver) Provisioner {
 			DockerOptionsDir:  "/etc/docker",
 			DaemonOptionsFile: "/etc/default/docker",
 			KubernetesManifestFile: "/tmp/master.json",
+			KubernetesKubeletPath: "/usr/local/bin/kubelet",
 			OsReleaseId:       "ubuntu",
 			Packages: []string{
 				"curl",
@@ -159,6 +160,10 @@ func (provisioner *UbuntuProvisioner) Provision(k8sOptions kubernetes.Kubernetes
 	}
 
 	if err := installk8sGeneric(provisioner); err != nil {
+		return err
+	}
+
+	if err := configureKubernetes(provisioner, &provisioner.KubernetesOptions, authOptions); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
On Digital Ocean and AWS, the kubelet is spawned inside a docker container.  This fix changes the behavior to more closely match boot2docker by creating an init script to start/stop the kubernetes service.

There is an additional fix to the build setup so that the kmachine binaries are now in $SRC/bin instead of $SRC/bin/bin.